### PR TITLE
Implement new logging system in DingoEngine

### DIFF
--- a/DingoEngine/include/DingoEngine/Core/LayerStack.h
+++ b/DingoEngine/include/DingoEngine/Core/LayerStack.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 namespace DingoEngine
 {
 

--- a/DingoEngine/include/DingoEngine/Graphics/Shader.h
+++ b/DingoEngine/include/DingoEngine/Graphics/Shader.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 
 #include <nvrhi/nvrhi.h>
+#include <unordered_map>
 
 namespace DingoEngine
 {

--- a/DingoEngine/include/DingoEngine/Log.h
+++ b/DingoEngine/include/DingoEngine/Log.h
@@ -1,13 +1,8 @@
 #pragma once
-#include <spdlog/spdlog.h>
-#include <spdlog/fmt/ostr.h>
-
 #include <memory>
+#include <format>
 
-namespace spdlog
-{
-	class logger;
-}
+#include <glm/glm.hpp>
 
 namespace DingoEngine
 {
@@ -15,36 +10,112 @@ namespace DingoEngine
 	class Log
 	{
 	public:
+		enum class Type : uint8_t
+		{
+			Engine,
+			Client
+		};
+
+		enum class Level : uint8_t
+		{
+			Trace,
+			Info,
+			Warn,
+			Error,
+			Fatal
+		};
+
+	public:
 		static void Initialize();
 		static void Shutdown();
 
-		static std::shared_ptr<spdlog::logger> GetEngineLogger()
-		{
-			return s_EngineLogger;
-		}
-		static std::shared_ptr<spdlog::logger> GetClientLogger()
-		{
-			return s_ClientLogger;
-		}
+		template<typename... Args>
+		static void Print(Log::Type type, Log::Level level, std::format_string<Args...> format, Args&&... args);
+
+		template<typename... Args>
+		static void PrintTag(Log::Type type, Log::Level level, std::string_view tag, std::format_string<Args...> format, Args&&... args);
+
 	private:
-		static std::shared_ptr<spdlog::logger> s_EngineLogger;
-		static std::shared_ptr<spdlog::logger> s_ClientLogger;
+		static void PrintInternal(Log::Type type, Log::Level level, const std::string_view formatted);
+		static void PrintInternalTag(Log::Type type, Log::Level level, const std::string_view tag, const std::string_view formatted);
 	};
 
 }
 
 // Core log macros
-#define DE_CORE_TRACE(...)		::DingoEngine::Log::GetEngineLogger()->trace(__VA_ARGS__)
-#define DE_CORE_INFO(...)		::DingoEngine::Log::GetEngineLogger()->info(__VA_ARGS__)
-#define DE_CORE_WARN(...)		::DingoEngine::Log::GetEngineLogger()->warn(__VA_ARGS__)
-#define DE_CORE_ERROR(...)		::DingoEngine::Log::GetEngineLogger()->error(__VA_ARGS__)
-#define DE_CORE_FATAL(...)		::DingoEngine::Log::GetEngineLogger()->critical(__VA_ARGS__)
+#define DE_CORE_TRACE(...)				::DingoEngine::Log::Print(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Trace, __VA_ARGS__)
+#define DE_CORE_INFO(...)				::DingoEngine::Log::Print(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Info, __VA_ARGS__)
+#define DE_CORE_WARN(...)				::DingoEngine::Log::Print(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Warn, __VA_ARGS__)
+#define DE_CORE_ERROR(...)				::DingoEngine::Log::Print(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Error, __VA_ARGS__)
+#define DE_CORE_FATAL(...)				::DingoEngine::Log::Print(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Fatal, __VA_ARGS__)
 
 // Client log macros
-#define DE_TRACE(...)			::DingoEngine::Log::GetClientLogger()->trace(__VA_ARGS__)
-#define DE_INFO(...)			::DingoEngine::Log::GetClientLogger()->info(__VA_ARGS__)
-#define DE_WARN(...)			::DingoEngine::Log::GetClientLogger()->warn(__VA_ARGS__)
-#define DE_ERROR(...)			::DingoEngine::Log::GetClientLogger()->error(__VA_ARGS__)
-#define DE_FATAL(...)			::DingoEngine::Log::GetClientLogger()->critical(__VA_ARGS__)
+#define DE_TRACE(...)					::DingoEngine::Log::Print(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Trace, __VA_ARGS__)
+#define DE_INFO(...)					::DingoEngine::Log::Print(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Info, __VA_ARGS__)
+#define DE_WARN(...)					::DingoEngine::Log::Print(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Warn, __VA_ARGS__)
+#define DE_ERROR(...)					::DingoEngine::Log::Print(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Error, __VA_ARGS__)
+#define DE_FATAL(...)					::DingoEngine::Log::Print(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Fatal, __VA_ARGS__)
 
-#include "Assertion.h"
+
+// Engine log macros (tagged)
+#define DE_CORE_TRACE_TAG(tag, ...)		::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Trace, tag, __VA_ARGS__)
+#define DE_CORE_INFO_TAG(tag, ...)		::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Info, tag, __VA_ARGS__)
+#define DE_CORE_WARN_TAG(tag, ...)		::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Warn, tag, __VA_ARGS__)
+#define DE_CORE_ERROR_TAG(tag, ...)		::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Error, tag, __VA_ARGS__)
+#define DE_CORE_FATAL_TAG(tag, ...)		::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Engine, ::DingoEngine::Log::Level::Fatal, tag, __VA_ARGS__)
+
+// Client log macros (tagged)
+#define DE_TRACE_TAG(tag, ...)			::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Trace, tag, __VA_ARGS__)
+#define DE_INFO_TAG(tag, ...)			::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Info, tag, __VA_ARGS__)
+#define DE_WARN_TAG(tag, ...)			::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Warn, tag, __VA_ARGS__)
+#define DE_ERROR_TAG(tag, ...)			::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Error, tag, __VA_ARGS__)
+#define DE_FATAL_TAG(tag, ...)			::DingoEngine::Log::PrintTag(::DingoEngine::Log::Type::Client, ::DingoEngine::Log::Level::Fatal, tag, __VA_ARGS__)
+
+namespace DingoEngine
+{
+
+	template<typename ...Args>
+	inline void Log::Print(Log::Type type, Log::Level level, std::format_string<Args...> format, Args && ...args)
+	{
+		PrintInternal(type, level, std::format(format, std::forward<Args>(args)...));
+	}
+
+	template<typename ...Args>
+	inline void Log::PrintTag(Log::Type type, Log::Level level, std::string_view tag, std::format_string<Args...> format, Args && ...args)
+	{
+		PrintInternalTag(type, level, tag, std::format(format, std::forward<Args>(args)...));
+	}
+
+}
+
+template<>
+struct std::formatter<glm::vec2> : std::formatter<std::string>
+{
+	template<typename FormatContext>
+	auto format(const glm::vec2& vec, FormatContext& ctx) const
+	{
+		return std::formatter<std::string>::format(std::format("({}, {})", vec.x, vec.y), ctx);
+	}
+};
+
+template<>
+struct std::formatter<glm::vec3> : std::formatter<std::string>
+{
+	template<typename FormatContext>
+	auto format(const glm::vec3& vec, FormatContext& ctx) const
+	{
+		return std::formatter<std::string>::format(std::format("({}, {}, {})", vec.x, vec.y, vec.z), ctx);
+	}
+};
+
+template<>
+struct std::formatter<glm::vec4> : std::formatter<std::string>
+{
+	template<typename FormatContext>
+	auto format(const glm::vec4& vec, FormatContext& ctx) const
+	{
+		return std::formatter<std::string>::format(std::format("({}, {}, {}, {})", vec.x, vec.y, vec.z, vec.w), ctx);
+	}
+};
+
+

--- a/DingoEngine/premake5.lua
+++ b/DingoEngine/premake5.lua
@@ -38,7 +38,8 @@ project "DingoEngine"
 	}
 
 	defines {
-		"GLFW_INCLUDE_NONE"
+		"GLFW_INCLUDE_NONE",
+		"SPDLOG_USE_STD_FORMAT"
 	}
 
 	buildoptions {

--- a/DingoEngine/src/DingoEngine/Log.cpp
+++ b/DingoEngine/src/DingoEngine/Log.cpp
@@ -1,14 +1,35 @@
 #include "depch.h"
 #include "DingoEngine/Log.h"
 
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/ostr.h>
+
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/basic_file_sink.h>
 
 namespace DingoEngine
 {
 
-	std::shared_ptr<spdlog::logger> Log::s_EngineLogger;
-	std::shared_ptr<spdlog::logger> Log::s_ClientLogger;
+	static std::shared_ptr<spdlog::logger> s_EngineLogger;
+	static std::shared_ptr<spdlog::logger> s_ClientLogger;
+
+	namespace Utils
+	{
+
+		static std::shared_ptr<spdlog::logger> GetLogger(Log::Type type)
+		{
+			switch (type)
+			{
+				case Log::Type::Engine: return s_EngineLogger;
+				case Log::Type::Client: return s_ClientLogger;
+				default: break;
+			}
+
+			DE_CORE_ASSERT(false, "Unknown Log Type");
+			return nullptr;
+		}
+
+	}
 
 	void Log::Initialize()
 	{
@@ -35,6 +56,54 @@ namespace DingoEngine
 		s_ClientLogger.reset();
 		s_EngineLogger.reset();
 		spdlog::drop_all();
+	}
+
+	void Log::PrintInternal(Log::Type type, Log::Level level, const std::string_view formatted)
+	{
+		auto logger = Utils::GetLogger(type);
+
+		switch (level)
+		{
+			case DingoEngine::Log::Level::Trace:
+				logger->trace(formatted);
+				break;
+			case DingoEngine::Log::Level::Info:
+				logger->info(formatted);
+				break;
+			case DingoEngine::Log::Level::Warn:
+				logger->warn(formatted);
+				break;
+			case DingoEngine::Log::Level::Error:
+				logger->error(formatted);
+				break;
+			case DingoEngine::Log::Level::Fatal:
+				logger->critical(formatted);
+				break;
+		}
+	}
+
+	void Log::PrintInternalTag(Log::Type type, Log::Level level, const std::string_view tag, const std::string_view formatted)
+	{
+		auto logger = Utils::GetLogger(type);
+
+		switch (level)
+		{
+			case DingoEngine::Log::Level::Trace:
+				logger->trace("[{}] {}", tag, formatted);
+				break;
+			case DingoEngine::Log::Level::Info:
+				logger->info("[{}] {}", tag, formatted);
+				break;
+			case DingoEngine::Log::Level::Warn:
+				logger->warn("[{}] {}", tag, formatted);
+				break;
+			case DingoEngine::Log::Level::Error:
+				logger->error("[{}] {}", tag, formatted);
+				break;
+			case DingoEngine::Log::Level::Fatal:
+				logger->critical("[{}] {}", tag, formatted);
+				break;
+		}
 	}
 
 }

--- a/DingoEngine/src/depch.h
+++ b/DingoEngine/src/depch.h
@@ -5,11 +5,15 @@
 #endif
 
 #include <filesystem>
+#include <fstream>
 #include <string>
 #include <sstream>
 #include <vector>
 #include <optional>
 #include <unordered_set>
+#include <memory>
+#include <format>
+#include <string_view>
 
 #include "DingoEngine/Assertion.h"
 

--- a/Sandbox/premake5.lua
+++ b/Sandbox/premake5.lua
@@ -16,17 +16,12 @@ project "Sandbox"
         "src",
         "%{IncludeDir.glm}",
 
-        "%{IncludeDir.spdlog}", -- TODO: Client apps should not depend on this...
         "%{IncludeDir.nvrhi}" -- TODO: Client apps should not depend on this...
     }
 
     links { 
 		"DingoEngine"
 	}
-
-    buildoptions {
-        "/utf-8"
-    }
 
 	filter "system:windows"
 		systemversion "latest"

--- a/Sandbox/src/main.cpp
+++ b/Sandbox/src/main.cpp
@@ -32,11 +32,31 @@ int main()
 
 	DingoEngine::Log::Initialize();
 
+	DE_CORE_TRACE("ENGINE {}", "TRACE");
+	DE_CORE_INFO("ENGINE {}", "INFO");
+	DE_CORE_WARN("ENGINE {}", "WARN");
+	DE_CORE_ERROR("ENGINE {}", "ERROR");
+	DE_CORE_FATAL("ENGINE {}", "FATAL");
+
 	DE_TRACE("TRACE");
 	DE_INFO("INFO");
 	DE_WARN("WARN");
 	DE_ERROR("ERROR");
 	DE_FATAL("FATAL");
+
+#ifdef USE_STD_FMT
+	DE_CORE_TRACE_TAG("TAG", "ENGINE {} {}", "TRACE", glm::vec2(69.0f, 420.0f));
+	DE_CORE_INFO_TAG("TAG", "ENGINE {}", "INFO");
+	DE_CORE_WARN_TAG("TAG", "ENGINE {}", "WARN");
+	DE_CORE_ERROR_TAG("TAG", "ENGINE {}", "ERROR");
+	DE_CORE_FATAL_TAG("TAG", "ENGINE {}", "FATAL");
+
+	DE_TRACE_TAG("TAG", "TRACE");
+	DE_INFO_TAG("TAG", "INFO");
+	DE_WARN_TAG("TAG", "WARN");
+	DE_ERROR_TAG("TAG", "ERROR");
+	DE_FATAL_TAG("TAG", "FATAL");
+#endif
 
 	DingoEngine::Application* app = DingoEngine::CreateApplication();
 	app->Run();


### PR DESCRIPTION
This commit replaces the previous spdlog-based logger with a more flexible and formatted logging approach. The `Log` class now supports different severity levels and tagged logging. Logging macros have been updated for formatted output, and direct references to spdlog have been removed in favor of an abstracted logging utility. The `Log.cpp` and `Log.h` files have been modified to include new internal methods for handling log messages. Additionally, the `premake5.lua` files for both the DingoEngine and Sandbox projects have been updated to include new dependencies and definitions. The `main.cpp` file demonstrates the new logging functionality with various log levels and tags.