### PR TITLE
feat: shader SPIR-V caching

### DIFF
--- a/src/DingoEngine/Graphics/NVRHI/NvrhiShader.h
+++ b/src/DingoEngine/Graphics/NVRHI/NvrhiShader.h
@@ -20,9 +20,12 @@ namespace Dingo
 		virtual void Destroy() override;
 
 	private:
-		std::unordered_map<ShaderType, std::string> PreProcess(const std::string& source);
 		nvrhi::ShaderHandle CreateShaderHandle(nvrhi::ShaderType shaderType, const std::vector<uint32_t>& spvbinary, const std::string& debugName = "Shader");
 		void CreateBindingLayoutHandle(const std::vector<ShaderReflection>& reflection);
+
+		std::unordered_map<ShaderType, std::vector<uint32_t>> CompileOrGetShaderBinaries(const std::unordered_map<ShaderType, std::string>& sources, const std::string& name, ShaderCompiler& compiler);
+		std::unordered_map<ShaderType, std::string> GetShaderSources() const;
+		std::unordered_map<ShaderType, std::string> PreProcess(const std::string& source) const;
 
 	private:
 		std::unordered_map<ShaderType, nvrhi::ShaderHandle> m_ShaderHandles;


### PR DESCRIPTION
Add methods to compile or retrieve shader binaries from cache and to get shader sources. Refactor shader compilation logic for better organization and clarity.