### PR TITLE
feat: add CacheManager for shader caching

### DIFF
--- a/include/DingoEngine/Core/CacheManager.h
+++ b/include/DingoEngine/Core/CacheManager.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <filesystem>
+
+namespace Dingo
+{
+
+	class CacheManager
+	{
+	public:
+		static void Initialize();
+		static void Shutdown();
+
+		static std::filesystem::path GetCacheBaseDirectory();
+		static std::filesystem::path GetCacheDirectory(const std::filesystem::path& subCacheDirectory);
+	};
+
+}

--- a/src/DingoEngine/Core/Application.cpp
+++ b/src/DingoEngine/Core/Application.cpp
@@ -2,6 +2,7 @@
 #include "DingoEngine/Core/Application.h"
 #include "DingoEngine/Core/Timer.h"
 #include "DingoEngine/Core/Layer.h"
+#include "DingoEngine/Core/CacheManager.h"
 #include "DingoEngine/Core/Layers/EmptyLayer.h"
 #include "DingoEngine/Graphics/AppRenderer.h"
 
@@ -27,6 +28,8 @@ namespace Dingo
 	void Application::Initialize()
 	{
 		DE_CORE_ASSERT(s_Instance, "Application already initialized. Cannot initialize again.");
+
+		CacheManager::Initialize();
 
 		m_Window = new Window(m_Params.Window);
 		m_Window->SetEventCallback(DE_BIND_EVENT_FN(Application::OnEvent));
@@ -107,6 +110,8 @@ namespace Dingo
 			//delete m_GraphicsContext;
 			m_GraphicsContext = nullptr;
 		}
+
+		CacheManager::Shutdown();
 	}
 
 	void Application::OnEvent(Event& e)

--- a/src/DingoEngine/Core/CacheManager.cpp
+++ b/src/DingoEngine/Core/CacheManager.cpp
@@ -1,0 +1,40 @@
+#include "depch.h"
+#include "DingoEngine/Core/CacheManager.h"
+
+namespace Dingo
+{
+
+	void CacheManager::Initialize()
+	{
+		if (!std::filesystem::exists(GetCacheBaseDirectory()))
+		{
+			std::filesystem::create_directories(GetCacheBaseDirectory());
+		}
+
+		// Initialize cache manager resources here
+	}
+
+	void CacheManager::Shutdown()
+	{
+		// Clean up cache manager resources here
+	}
+
+	std::filesystem::path CacheManager::GetCacheBaseDirectory()
+	{
+		return std::filesystem::current_path() / ".cache";
+	}
+
+	std::filesystem::path CacheManager::GetCacheDirectory(const std::filesystem::path& subCacheDirectory)
+	{
+		DE_CORE_ASSERT(!subCacheDirectory.empty(), "Sub-cache directory cannot be empty.");
+
+		std::filesystem::path directory = GetCacheBaseDirectory() / subCacheDirectory;
+		if (!std::filesystem::exists(directory))
+		{
+			std::filesystem::create_directories(directory);
+		}
+
+		return directory;
+	}
+
+} // namespace Dingo

--- a/src/DingoEngine/Graphics/NVRHI/NvrhiShader.cpp
+++ b/src/DingoEngine/Graphics/NVRHI/NvrhiShader.cpp
@@ -1,6 +1,7 @@
 #include "depch.h"
 #include "NvrhiShader.h"
 
+#include "DingoEngine/Core/CacheManager.h"
 #include "DingoEngine/Core/FileSystem.h"
 #include "DingoEngine/Graphics/GraphicsContext.h"
 #include "DingoEngine/Graphics/ShaderCompiler.h"
@@ -191,11 +192,7 @@ namespace Dingo
 
 		for (const auto& [shaderType, source] : sources)
 		{
-			std::filesystem::path cachePath = std::filesystem::current_path() / ".cache" / "shaders";
-			if(!std::filesystem::exists(cachePath))
-			{
-				std::filesystem::create_directories(cachePath);
-			}
+			const std::filesystem::path& cachePath = CacheManager::GetCacheDirectory("shaders");
 			std::filesystem::path shaderCacheFilePath = cachePath / (name + "_" + Utils::ConvertShaderTypeToString(shaderType) + ".spv");
 
 			if (std::filesystem::exists(shaderCacheFilePath))


### PR DESCRIPTION
Introduced a new `CacheManager` class to handle cache directories for shaders, including initialization and shutdown methods. Updated the `Application` and `NvrhiShader` classes to utilize the `CacheManager` for improved cache management.